### PR TITLE
Use Esprima 2.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var esprima = require('esprima-fb'),
+var esprima = require('esprima'),
     parse = require('./lib/parse.js');
 
 function find(fileContents, options) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,5 +1,5 @@
 var lang = require('./lang.js'),
-    esprima = require('esprima-fb');
+    esprima = require('esprima');
 
 /**
  * @license Copyright (c) 2010-2014, The Dojo Foundation All Rights Reserved.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "author": "Mikito Takada <mikito.takada@gmail.com> (http://mixu.net/)",
   "license": "BSD",
   "dependencies": {
-    "esprima-fb": "^15001.1001.0-dev-harmony-fb"
+    "esprima": "~2.7.0"
   }
 }


### PR DESCRIPTION
Like I mentioned earlier https://github.com/mixu/amdetective/pull/3#issuecomment-150482167, it is better to use the upstream Esprima 2.x for ES6 support.