### PR TITLE
Add arrow function support for named module without dependency

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -745,7 +745,7 @@ parse.parseNode = function (node, onMatch) {
         }
 
         if (name && name.type === 'Literal' && deps) {
-            if (deps.type === 'FunctionExpression') {
+            if (deps.type === 'FunctionExpression' || deps.type === 'ArrowFunctionExpression') {
                 //deps is the factory
                 factory = deps;
                 deps = null;
@@ -760,7 +760,7 @@ parse.parseNode = function (node, onMatch) {
 
         if (deps && deps.type === 'ArrayExpression') {
             deps = getValidDeps(deps);
-        } else if (factory && factory.type === 'FunctionExpression') {
+        } else if (factory && factory.type === 'FunctionExpression' || factory.type === 'ArrowFunctionExpression') {
             //If no deps and a factory function, could be a commonjs sugar
             //wrapper, scan the function for dependencies.
             cjsDeps = parse.getAnonDepsFromNode(factory);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -760,7 +760,7 @@ parse.parseNode = function (node, onMatch) {
 
         if (deps && deps.type === 'ArrayExpression') {
             deps = getValidDeps(deps);
-        } else if (factory && factory.type === 'FunctionExpression' || factory.type === 'ArrowFunctionExpression') {
+        } else if (factory && (factory.type === 'FunctionExpression' || factory.type === 'ArrowFunctionExpression')) {
             //If no deps and a factory function, could be a commonjs sugar
             //wrapper, scan the function for dependencies.
             cjsDeps = parse.getAnonDepsFromNode(factory);

--- a/test/test.js
+++ b/test/test.js
@@ -73,6 +73,11 @@ describe('amdetective', function() {
     assert.deepEqual(amdetective(input), [ { name: 'foo/title', deps: [ 'my/cart', 'my/inventory' ] } ]);
   });
 
+  it('works on a Module with a name, no dependency and arrow function as factory', function() {
+    var input = 'define("foo/title", () => { /* Define foo/title object in here. */ });';
+    assert.deepEqual(amdetective(input), [ { name: 'foo/title', deps: [] } ]);
+  });
+
   it('works on a named module with relative module names inside define()', function() {
     var input = [
       'define("foo/title", function() {',


### PR DESCRIPTION
On the following sample, `amdetective` does not output the name of the module and empty dependency array (the output is `[]`)

```javascript
define('some/cool/id', () => {
  console.log('that will fail.');
});
```

Whereas on this one it does behave as expected (the output is `[{ name: 'some/cool/id', deps: [] }]`)

```javascript
define('some/cool/id', function () {
  console.log('that will fail.');
});
```