### PR TITLE
Updated parse.js and lang.js from latest changes from r.js

### DIFF
--- a/lib/lang.js
+++ b/lib/lang.js
@@ -14,7 +14,9 @@ isJavaObj = function () {
     return false;
 };
 
-if (typeof java !== 'undefined' && java.lang && java.lang.Object) {
+//Rhino, but not Nashorn (detected by importPackage not existing)
+//Can have some strange foreign objects.
+if (typeof java !== 'undefined' && java.lang && java.lang.Object && typeof importPackage !== 'undefined') {
     isJavaObj = function (obj) {
         return obj instanceof java.lang.Object;
     };
@@ -81,6 +83,31 @@ lang = {
         return dest; // Object
     },
 
+    /**
+     * Does a deep mix of source into dest, where source values override
+     * dest values if a winner is needed.
+     * @param  {Object} dest destination object that receives the mixed
+     * values.
+     * @param  {Object} source source object contributing properties to mix
+     * in.
+     * @return {[Object]} returns dest object with the modification.
+     */
+    deepMix: function(dest, source) {
+        lang.eachProp(source, function (value, prop) {
+            if (typeof value === 'object' && value &&
+                !lang.isArray(value) && !lang.isFunction(value) &&
+                !(value instanceof RegExp)) {
+
+                if (!dest[prop]) {
+                    dest[prop] = {};
+                }
+                lang.deepMix(dest[prop], value);
+            } else {
+                dest[prop] = value;
+            }
+        });
+        return dest;
+    },
 
     /**
      * Does a type of deep copy. Do not give it anything fancy, best
@@ -88,16 +115,17 @@ lang = {
      * JSON-serialized things, or has properties pointing to functions.
      * For non-array/object values, just returns the same object.
      * @param  {Object} obj      copy properties from this object
-     * @param  {Object} [result] optional result object to use
+     * @param  {Object} [ignoredProps] optional object whose own properties
+     * are keys that should be ignored.
      * @return {Object}
      */
-    deeplikeCopy: function (obj) {
+    deeplikeCopy: function (obj, ignoredProps) {
         var type, result;
 
         if (lang.isArray(obj)) {
             result = [];
             obj.forEach(function(value) {
-                result.push(lang.deeplikeCopy(value));
+                result.push(lang.deeplikeCopy(value, ignoredProps));
             });
             return result;
         }
@@ -112,7 +140,9 @@ lang = {
         //Anything else is an object, hopefully.
         result = {};
         lang.eachProp(obj, function(value, key) {
-            result[key] = lang.deeplikeCopy(value);
+            if (!ignoredProps || !hasProp(ignoredProps, key)) {
+                result[key] = lang.deeplikeCopy(value, ignoredProps);
+            }
         });
         return result;
     },

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -21,11 +21,15 @@ function arrayToString(ary) {
 
 //This string is saved off because JSLint complains
 //about obj.arguments use, as 'reserved word'
-var argPropName = 'arguments';
+var argPropName = 'arguments',
+    //Default object to use for "scope" checking for UMD identifiers.
+    emptyScope = {},
+    mixin = lang.mixin,
+    hasProp = lang.hasProp;
 
 //From an esprima example for traversing its ast.
 function traverse(object, visitor) {
-    var key, child;
+    var child;
 
     if (!object) {
         return;
@@ -34,13 +38,11 @@ function traverse(object, visitor) {
     if (visitor.call(null, object) === false) {
         return false;
     }
-    for (key in object) {
-        if (object.hasOwnProperty(key)) {
-            child = object[key];
-            if (typeof child === 'object' && child !== null) {
-                if (traverse(child, visitor) === false) {
-                    return false;
-                }
+    for (var i = 0, keys = Object.keys(object); i < keys.length; i++) {
+        child = object[keys[i]];
+        if (typeof child === 'object' && child !== null) {
+            if (traverse(child, visitor) === false) {
+                return false;
             }
         }
     }
@@ -50,7 +52,7 @@ function traverse(object, visitor) {
 //stops that subtree analysis, not the rest of tree
 //visiting.
 function traverseBroad(object, visitor) {
-    var key, child;
+    var child;
 
     if (!object) {
         return;
@@ -59,12 +61,10 @@ function traverseBroad(object, visitor) {
     if (visitor.call(null, object) === false) {
         return false;
     }
-    for (key in object) {
-        if (object.hasOwnProperty(key)) {
-            child = object[key];
-            if (typeof child === 'object' && child !== null) {
-                traverse(child, visitor);
-            }
+    for (var i = 0, keys = Object.keys(object); i < keys.length; i++) {
+        child = object[key];
+        if (typeof child === 'object' && child !== null) {
+            traverseBroad(child, visitor);
         }
     }
 }
@@ -96,6 +96,13 @@ function getValidDeps(node) {
     return deps.length ? deps : undefined;
 }
 
+// Detects regular or arrow function expressions as the desired expression
+// type.
+function isFnExpression(node) {
+    return (node && (node.type === 'FunctionExpression' ||
+    node.type === 'ArrowFunctionExpression'));
+}
+
 /**
  * Main parse function. Returns a string of any valid require or
  * define/require.def calls as part of one JavaScript source string.
@@ -123,7 +130,7 @@ function parse(moduleName, fileName, fileContents, options) {
         needsDefine = true,
         astRoot = esprima.parse(fileContents);
 
-    parse.recurse(astRoot, function (callName, config, name, deps) {
+    parse.recurse(astRoot, function (callName, config, name, deps, node, factoryIdentifier, fnExpScope) {
         if (!deps) {
             deps = [];
         }
@@ -141,6 +148,10 @@ function parse(moduleName, fileName, fileContents, options) {
                 name: name,
                 deps: deps
             });
+        }
+
+        if (callName === 'define' && factoryIdentifier && hasProp(fnExpScope, factoryIdentifier)) {
+            return factoryIdentifier;
         }
 
         //If define was found, no need to dive deeper, unless
@@ -169,7 +180,7 @@ function parse(moduleName, fileName, fileContents, options) {
 
             depString = arrayToString(moduleCall.deps);
             result += 'define("' + moduleCall.name + '",' +
-                      depString + ');';
+                depString + ');';
         }
         if (moduleDeps.length) {
             if (result) {
@@ -185,6 +196,7 @@ function parse(moduleName, fileName, fileContents, options) {
 
 parse.traverse = traverse;
 parse.traverseBroad = traverseBroad;
+parse.isFnExpression = isFnExpression;
 
 /**
  * Handles parsing a file recursively for require calls.
@@ -192,13 +204,17 @@ parse.traverseBroad = traverseBroad;
  * @param {Function} onMatch function to call on a parse match.
  * @param {Object} [options] This is normally the build config options if
  * it is passed.
+ * @param {Object} [fnExpScope] holds list of function expresssion
+ * argument identifiers, set up internally, not passed in
  */
-parse.recurse = function (object, onMatch, options) {
+parse.recurse = function (object, onMatch, options, fnExpScope) {
     //Like traverse, but skips if branches that would not be processed
     //after has application that results in tests of true or false boolean
     //literal values.
-    var key, child,
+    var keys, child, result, i, params, param, tempObject,
         hasHas = options && options.has;
+
+    fnExpScope = fnExpScope || emptyScope;
 
     if (!object) {
         return;
@@ -207,25 +223,72 @@ parse.recurse = function (object, onMatch, options) {
     //If has replacement has resulted in if(true){} or if(false){}, take
     //the appropriate branch and skip the other one.
     if (hasHas && object.type === 'IfStatement' && object.test.type &&
-            object.test.type === 'Literal') {
+        object.test.type === 'Literal') {
         if (object.test.value) {
             //Take the if branch
-            this.recurse(object.consequent, onMatch, options);
+            this.recurse(object.consequent, onMatch, options, fnExpScope);
         } else {
             //Take the else branch
-            this.recurse(object.alternate, onMatch, options);
+            this.recurse(object.alternate, onMatch, options, fnExpScope);
         }
     } else {
-        if (this.parseNode(object, onMatch) === false) {
+        result = this.parseNode(object, onMatch, fnExpScope);
+        if (result === false) {
             return;
+        } else if (typeof result === 'string') {
+            return result;
         }
-        for (key in object) {
-            if (object.hasOwnProperty(key)) {
-                child = object[key];
-                if (typeof child === 'object' && child !== null) {
-                    this.recurse(child, onMatch, options);
+
+        //Build up a "scope" object that informs nested recurse calls if
+        //the define call references an identifier that is likely a UMD
+        //wrapped function expression argument.
+        //Catch (function(a) {... wrappers
+        if (object.type === 'ExpressionStatement' && object.expression &&
+            object.expression.type === 'CallExpression' && object.expression.callee &&
+            isFnExpression(object.expression.callee)) {
+            tempObject = object.expression.callee;
+        }
+        // Catch !function(a) {... wrappers
+        if (object.type === 'UnaryExpression' && object.argument &&
+            object.argument.type === 'CallExpression' && object.argument.callee &&
+            isFnExpression(object.argument.callee)) {
+            tempObject = object.argument.callee;
+        }
+        if (tempObject && tempObject.params && tempObject.params.length) {
+            params = tempObject.params;
+            fnExpScope = mixin({}, fnExpScope, true);
+            for (i = 0; i < params.length; i++) {
+                param = params[i];
+                if (param.type === 'Identifier') {
+                    fnExpScope[param.name] = true;
                 }
             }
+        }
+
+        for (i = 0, keys = Object.keys(object); i < keys.length; i++) {
+            child = object[keys[i]];
+            if (typeof child === 'object' && child !== null) {
+                result = this.recurse(child, onMatch, options, fnExpScope);
+                if (typeof result === 'string' && hasProp(fnExpScope, result)) {
+                    //The result was still in fnExpScope so break. Otherwise,
+                    //was a return from a a tree that had a UMD definition,
+                    //but now out of that scope so keep siblings.
+                    break;
+                }
+            }
+        }
+
+        //Check for an identifier for a factory function identifier being
+        //passed in as a function expression, indicating a UMD-type of
+        //wrapping.
+        if (typeof result === 'string') {
+            if (hasProp(fnExpScope, result)) {
+                //result still in scope, keep jumping out indicating the
+                //identifier still in use.
+                return result;
+            }
+
+            return;
         }
     }
 };
@@ -238,18 +301,56 @@ parse.recurse = function (object, onMatch, options) {
  * @returns {Boolean}
  */
 parse.definesRequire = function (fileName, fileContents) {
-    var found = false;
+    var foundDefine = false,
+        foundDefineAmd = false;
 
     traverse(esprima.parse(fileContents), function (node) {
-        if (parse.hasDefineAmd(node)) {
-            found = true;
+        // Look for a top level declaration of a define, like
+        // var requirejs, require, define, off Program body.
+        if (node.type === 'Program' && node.body && node.body.length) {
+            foundDefine = node.body.some(function(bodyNode) {
+                // var define
+                if (bodyNode.type === 'VariableDeclaration') {
+                    var decls = bodyNode.declarations;
+                    if (decls) {
+                        var hasVarDefine = decls.some(function(declNode) {
+                            return (declNode.type === 'VariableDeclarator' &&
+                            declNode.id &&
+                            declNode.id.type === 'Identifier' &&
+                            declNode.id.name === 'define');
+                        });
+                        if (hasVarDefine) {
+                            return true;
+                        }
+                    }
+                }
+
+                // function define() {}
+                if (bodyNode.type === 'FunctionDeclaration' &&
+                    bodyNode.id &&
+                    bodyNode.id.type === 'Identifier' &&
+                    bodyNode.id.name === 'define') {
+                    return true;
+                }
+
+
+
+
+
+
+            });
+        }
+
+        // Need define variable found first, before detecting define.amd.
+        if (foundDefine && parse.hasDefineAmd(node)) {
+            foundDefineAmd = true;
 
             //Stop traversal
             return false;
         }
     });
 
-    return found;
+    return foundDefine && foundDefineAmd;
 };
 
 /**
@@ -265,7 +366,7 @@ parse.definesRequire = function (fileName, fileContents) {
  */
 parse.getAnonDeps = function (fileName, fileContents) {
     var astRoot = typeof fileContents === 'string' ?
-                  esprima.parse(fileContents) : fileContents,
+            esprima.parse(fileContents) : fileContents,
         defFunc = this.findAnonDefineFactory(astRoot);
 
     return parse.getAnonDepsFromNode(defFunc);
@@ -291,7 +392,7 @@ parse.getAnonDepsFromNode = function (node) {
         funcArgLength = node.params && node.params.length;
         if (funcArgLength) {
             deps = (funcArgLength > 1 ? ["require", "exports", "module"] :
-                    ["require"]).concat(deps);
+                ["require"]).concat(deps);
         }
     }
     return deps;
@@ -299,8 +400,8 @@ parse.getAnonDepsFromNode = function (node) {
 
 parse.isDefineNodeWithArgs = function (node) {
     return node && node.type === 'CallExpression' &&
-           node.callee && node.callee.type === 'Identifier' &&
-           node.callee.name === 'define' && node[argPropName];
+        node.callee && node.callee.type === 'Identifier' &&
+        node.callee.name === 'define' && node[argPropName];
 };
 
 /**
@@ -318,15 +419,14 @@ parse.findAnonDefineFactory = function (node) {
 
             //Just the factory function passed to define
             arg0 = node[argPropName][0];
-            if (arg0 && arg0.type === 'FunctionExpression') {
+            if (isFnExpression(arg0)) {
                 match = arg0;
                 return false;
             }
 
             //A string literal module ID followed by the factory function.
             arg1 = node[argPropName][1];
-            if (arg0.type === 'Literal' &&
-                    arg1 && arg1.type === 'FunctionExpression') {
+            if (arg0.type === 'Literal' && isFnExpression(arg1)) {
                 match = arg1;
                 return false;
             }
@@ -363,9 +463,9 @@ parse.findConfig = function (fileContents) {
             requireType = parse.hasRequire(node);
 
         if (requireType && (requireType === 'require' ||
-                requireType === 'requirejs' ||
-                requireType === 'requireConfig' ||
-                requireType === 'requirejsConfig')) {
+            requireType === 'requirejs' ||
+            requireType === 'requireConfig' ||
+            requireType === 'requirejsConfig')) {
 
             arg = node[argPropName] && node[argPropName][0];
 
@@ -405,8 +505,8 @@ parse.findConfig = function (fileContents) {
  */
 parse.getRequireObjectLiteral = function (node) {
     if (node.id && node.id.type === 'Identifier' &&
-            (node.id.name === 'require' || node.id.name === 'requirejs') &&
-            node.init && node.init.type === 'ObjectExpression') {
+        (node.id.name === 'require' || node.id.name === 'requirejs') &&
+        node.init && node.init.type === 'ObjectExpression') {
         return node.init;
     }
 };
@@ -443,14 +543,14 @@ parse.renameNamespace = function (fileContents, ns) {
         locs.reverse();
         locs.forEach(function (loc) {
             var startIndex = loc.start.column,
-            //start.line is 1-based, not 0 based.
-            lineIndex = loc.start.line - 1,
-            line = lines[lineIndex];
+                //start.line is 1-based, not 0 based.
+                lineIndex = loc.start.line - 1,
+                line = lines[lineIndex];
 
             lines[lineIndex] = line.substring(0, startIndex) +
-                               ns + '.' +
-                               line.substring(startIndex,
-                                                  line.length);
+                ns + '.' +
+                line.substring(startIndex,
+                    line.length);
         });
 
         fileContents = lines.join('\n');
@@ -492,9 +592,9 @@ parse.findCjsDependencies = function (fileName, fileContents) {
         var arg;
 
         if (node && node.type === 'CallExpression' && node.callee &&
-                node.callee.type === 'Identifier' &&
-                node.callee.name === 'require' && node[argPropName] &&
-                node[argPropName].length === 1) {
+            node.callee.type === 'Identifier' &&
+            node.callee.name === 'require' && node[argPropName] &&
+            node[argPropName].length === 1) {
             arg = node[argPropName][0];
             if (arg.type === 'Literal') {
                 dependencies.push(arg.value);
@@ -508,7 +608,7 @@ parse.findCjsDependencies = function (fileName, fileContents) {
 //function define() {}
 parse.hasDefDefine = function (node) {
     return node.type === 'FunctionDeclaration' && node.id &&
-                node.id.type === 'Identifier' && node.id.name === 'define';
+        node.id.type === 'Identifier' && node.id.name === 'define';
 };
 
 //define.amd = ...
@@ -522,10 +622,10 @@ parse.hasDefineAmd = function (node) {
 //define.amd reference, as in: if (define.amd)
 parse.refsDefineAmd = function (node) {
     return node && node.type === 'MemberExpression' &&
-    node.object && node.object.name === 'define' &&
-    node.object.type === 'Identifier' &&
-    node.property && node.property.name === 'amd' &&
-    node.property.type === 'Identifier';
+        node.object && node.object.name === 'define' &&
+        node.object.type === 'Identifier' &&
+        node.property && node.property.name === 'amd' &&
+        node.property.type === 'Identifier';
 };
 
 //require(), requirejs(), require.config() and requirejs.config()
@@ -535,16 +635,16 @@ parse.hasRequire = function (node) {
 
     if (node && node.type === 'CallExpression' && c) {
         if (c.type === 'Identifier' &&
-                (c.name === 'require' ||
-                c.name === 'requirejs')) {
+            (c.name === 'require' ||
+            c.name === 'requirejs')) {
             //A require/requirejs({}, ...) call
             callName = c.name;
         } else if (c.type === 'MemberExpression' &&
-                c.object &&
-                c.object.type === 'Identifier' &&
-                (c.object.name === 'require' ||
-                    c.object.name === 'requirejs') &&
-                c.property && c.property.name === 'config') {
+            c.object &&
+            c.object.type === 'Identifier' &&
+            (c.object.name === 'require' ||
+            c.object.name === 'requirejs') &&
+            c.property && c.property.name === 'config') {
             // require/requirejs.config({}) call
             callName = c.object.name + 'Config';
         }
@@ -568,16 +668,43 @@ parse.getNamedDefine = function (fileContents) {
     var name;
     traverse(esprima.parse(fileContents), function (node) {
         if (node && node.type === 'CallExpression' && node.callee &&
-        node.callee.type === 'Identifier' &&
-        node.callee.name === 'define' &&
-        node[argPropName] && node[argPropName][0] &&
-        node[argPropName][0].type === 'Literal') {
+            node.callee.type === 'Identifier' &&
+            node.callee.name === 'define' &&
+            node[argPropName] && node[argPropName][0] &&
+            node[argPropName][0].type === 'Literal') {
             name = node[argPropName][0].value;
             return false;
         }
     });
 
     return name;
+};
+
+/**
+ * Finds all the named define module IDs in a file.
+ */
+parse.getAllNamedDefines = function (fileContents, excludeMap) {
+    var names = [];
+    parse.recurse(esprima.parse(fileContents),
+        function (callName, config, name, deps, node, factoryIdentifier, fnExpScope) {
+            if (callName === 'define' && name) {
+                if (!excludeMap.hasOwnProperty(name)) {
+                    names.push(name);
+                }
+            }
+
+            //If a UMD definition that points to a factory that is an Identifier,
+            //indicate processing should not traverse inside the UMD definition.
+            if (callName === 'define' && factoryIdentifier && hasProp(fnExpScope, factoryIdentifier)) {
+                return factoryIdentifier;
+            }
+
+            //If define was found, no need to dive deeper, unless
+            //the config explicitly wants to dig deeper.
+            return true;
+        }, {});
+
+    return names;
 };
 
 /**
@@ -600,7 +727,7 @@ parse.usesAmdOrRequireJs = function (fileName, fileContents) {
             if (callName) {
                 arg = node[argPropName] && node[argPropName][0];
                 if (arg && (arg.type === 'ObjectExpression' ||
-                        arg.type === 'ArrayExpression')) {
+                    arg.type === 'ArrayExpression')) {
                     type = callName;
                 }
             } else if (parse.hasDefine(node)) {
@@ -634,29 +761,34 @@ parse.usesCommonJs = function (fileName, fileContents) {
             exp = node.expression || node.init;
 
         if (node.type === 'Identifier' &&
-                (node.name === '__dirname' || node.name === '__filename')) {
+            (node.name === '__dirname' || node.name === '__filename')) {
             type = node.name.substring(2);
         } else if (node.type === 'VariableDeclarator' && node.id &&
-                node.id.type === 'Identifier' &&
-                    node.id.name === 'exports') {
+            node.id.type === 'Identifier' &&
+            node.id.name === 'exports') {
             //Hmm, a variable assignment for exports, so does not use cjs
             //exports.
             type = 'varExports';
         } else if (exp && exp.type === 'AssignmentExpression' && exp.left &&
-                exp.left.type === 'MemberExpression' && exp.left.object) {
+            exp.left.type === 'MemberExpression' && exp.left.object) {
             if (exp.left.object.name === 'module' && exp.left.property &&
-                    exp.left.property.name === 'exports') {
+                exp.left.property.name === 'exports') {
                 type = 'moduleExports';
             } else if (exp.left.object.name === 'exports' &&
-                    exp.left.property) {
+                exp.left.property) {
                 type = 'exports';
+            } else if (exp.left.object.type === 'MemberExpression' &&
+                exp.left.object.object.name === 'module' &&
+                exp.left.object.property.name === 'exports' &&
+                exp.left.object.property.type === 'Identifier') {
+                type = 'moduleExports';
             }
 
         } else if (node && node.type === 'CallExpression' && node.callee &&
-                node.callee.type === 'Identifier' &&
-                node.callee.name === 'require' && node[argPropName] &&
-                node[argPropName].length === 1 &&
-                node[argPropName][0].type === 'Literal') {
+            node.callee.type === 'Identifier' &&
+            node.callee.name === 'require' && node[argPropName] &&
+            node[argPropName].length === 1 &&
+            node[argPropName][0].type === 'Literal') {
             type = 'require';
         }
 
@@ -681,9 +813,9 @@ parse.findRequireDepNames = function (node, deps) {
         var arg;
 
         if (node && node.type === 'CallExpression' && node.callee &&
-                node.callee.type === 'Identifier' &&
-                node.callee.name === 'require' &&
-                node[argPropName] && node[argPropName].length === 1) {
+            node.callee.type === 'Identifier' &&
+            node.callee.name === 'require' &&
+            node[argPropName] && node[argPropName].length === 1) {
 
             arg = node[argPropName][0];
             if (arg.type === 'Literal') {
@@ -700,19 +832,23 @@ parse.findRequireDepNames = function (node, deps) {
  * @param {Function} onMatch a function to call when a match is found.
  * It is passed the match name, and the config, name, deps possible args.
  * The config, name and deps args are not normalized.
+ * @param {Object} fnExpScope an object whose keys are all function
+ * expression identifiers that should be in scope. Useful for UMD wrapper
+ * detection to avoid parsing more into the wrapped UMD code.
  *
  * @returns {String} a JS source string with the valid require/define call.
  * Otherwise null.
  */
-parse.parseNode = function (node, onMatch) {
+parse.parseNode = function (node, onMatch, fnExpScope) {
     var name, deps, cjsDeps, arg, factory, exp, refsDefine, bodyNode,
         args = node && node[argPropName],
-        callName = parse.hasRequire(node);
+        callName = parse.hasRequire(node),
+        isUmd = false;
 
     if (callName === 'require' || callName === 'requirejs') {
         //A plain require/requirejs call
         arg = node[argPropName] && node[argPropName][0];
-        if (arg.type !== 'ArrayExpression') {
+        if (arg && arg.type !== 'ArrayExpression') {
             if (arg.type === 'ObjectExpression') {
                 //A config call, try the second arg.
                 arg = node[argPropName][1];
@@ -735,39 +871,54 @@ parse.parseNode = function (node, onMatch) {
             factory = deps;
             deps = name;
             name = null;
-        } else if (name.type === 'FunctionExpression') {
+        } else if (isFnExpression(name)) {
             //Just the factory, no name or deps
             factory = name;
             name = deps = null;
+        } else if (name.type === 'Identifier' && args.length === 1 &&
+            hasProp(fnExpScope, name.name)) {
+            //define(e) where e is a UMD identifier for the factory
+            //function.
+            isUmd = true;
+            factory = name;
+            name = null;
         } else if (name.type !== 'Literal') {
-             //An object literal, just null out
+            //An object literal, just null out
             name = deps = factory = null;
         }
 
         if (name && name.type === 'Literal' && deps) {
-            if (deps.type === 'FunctionExpression' || deps.type === 'ArrowFunctionExpression') {
+            if (isFnExpression(deps)) {
                 //deps is the factory
                 factory = deps;
                 deps = null;
             } else if (deps.type === 'ObjectExpression') {
                 //deps is object literal, null out
                 deps = factory = null;
-            } else if (deps.type === 'Identifier' && args.length === 2) {
-                // define('id', factory)
-                deps = factory = null;
+            } else if (deps.type === 'Identifier') {
+                if (args.length === 2) {
+                    //define('id', factory)
+                    deps = factory = null;
+                } else if (args.length === 3 && isFnExpression(factory)) {
+                    //define('id', depsIdentifier, factory)
+                    //Since identifier, cannot know the deps, but do not
+                    //error out, assume they are taken care of outside of
+                    //static parsing.
+                    deps = null;
+                }
             }
         }
 
         if (deps && deps.type === 'ArrayExpression') {
             deps = getValidDeps(deps);
-        } else if (factory && (factory.type === 'FunctionExpression' || factory.type === 'ArrowFunctionExpression')) {
+        } else if (isFnExpression(factory)) {
             //If no deps and a factory function, could be a commonjs sugar
             //wrapper, scan the function for dependencies.
             cjsDeps = parse.getAnonDepsFromNode(factory);
             if (cjsDeps.length) {
                 deps = cjsDeps;
             }
-        } else if (deps || factory) {
+        } else if (deps || (factory && !isUmd)) {
             //Does not match the shape of an AMD call.
             return;
         }
@@ -777,12 +928,14 @@ parse.parseNode = function (node, onMatch) {
             name = name.value;
         }
 
-        return onMatch("define", null, name, deps, node);
+        return onMatch("define", null, name, deps, node,
+            (factory && factory.type === 'Identifier' ? factory.name : undefined),
+            fnExpScope);
     } else if (node.type === 'CallExpression' && node.callee &&
-               node.callee.type === 'FunctionExpression' &&
-               node.callee.body && node.callee.body.body &&
-               node.callee.body.body.length === 1 &&
-               node.callee.body.body[0].type === 'IfStatement') {
+        isFnExpression(node.callee) &&
+        node.callee.body && node.callee.body.body &&
+        node.callee.body.body.length === 1 &&
+        node.callee.body.body[0].type === 'IfStatement') {
         bodyNode = node.callee.body.body[0];
         //Look for a define(Identifier) case, but only if inside an
         //if that has a define.amd test
@@ -804,7 +957,8 @@ parse.parseNode = function (node, onMatch) {
                 });
 
                 if (refsDefine) {
-                    return onMatch("define", null, null, null, exp.expression);
+                    return onMatch("define", null, null, null, exp.expression,
+                        exp.expression.arguments[0].name, fnExpScope);
                 }
             }
         }
@@ -824,20 +978,20 @@ parse.nodeToString = function (contents, node) {
         loc = node.loc,
         lines = contents.split('\n'),
         firstLine = loc.start.line > 1 ?
-                    lines.slice(0, loc.start.line - 1).join('\n') + '\n' :
-                    '',
+        lines.slice(0, loc.start.line - 1).join('\n') + '\n' :
+            '',
         preamble = firstLine +
-                   lines[loc.start.line - 1].substring(0, loc.start.column);
+            lines[loc.start.line - 1].substring(0, loc.start.column);
 
     if (loc.start.line === loc.end.line) {
         extracted = lines[loc.start.line - 1].substring(loc.start.column,
-                                                        loc.end.column);
+            loc.end.column);
     } else {
         extracted =  lines[loc.start.line - 1].substring(loc.start.column) +
-                 '\n' +
-                 lines.slice(loc.start.line, loc.end.line - 1).join('\n') +
-                 '\n' +
-                 lines[loc.end.line - 1].substring(0, loc.end.column);
+            '\n' +
+            lines.slice(loc.start.line, loc.end.line - 1).join('\n') +
+            '\n' +
+            lines[loc.end.line - 1].substring(0, loc.end.column);
     }
 
     return {
@@ -886,7 +1040,7 @@ parse.getLicenseComments = function (fileName, contents) {
                     for (j = i + 1; j < ast.comments.length; j++) {
                         subNode = ast.comments[j];
                         if (subNode.type === 'Line' &&
-                                subNode.range[0] === refNode.range[1] + 1) {
+                            subNode.range[0] === refNode.range[1] + 1) {
                             //Adjacent single line comment. Collect it.
                             value += '//' + subNode.value + lineEnd;
                             refNode = subNode;
@@ -904,10 +1058,10 @@ parse.getLicenseComments = function (fileName, contents) {
             }
 
             if (!existsMap[value] && (value.indexOf('license') !== -1 ||
-                    (commentNode.type === 'Block' &&
-                        value.indexOf('/*!') === 0) ||
-                    value.indexOf('opyright') !== -1 ||
-                    value.indexOf('(c)') !== -1)) {
+                (commentNode.type === 'Block' &&
+                value.indexOf('/*!') === 0) ||
+                value.indexOf('opyright') !== -1 ||
+                value.indexOf('(c)') !== -1)) {
 
                 result += value;
                 existsMap[value] = true;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   "author": "Mikito Takada <mikito.takada@gmail.com> (http://mixu.net/)",
   "license": "BSD",
   "dependencies": {
-    "esprima": "~2.7.0"
+    "esprima": "3.1.0"
+  },
+  "devDependencies": {
+    "mocha": "^3.1.2"
   }
 }


### PR DESCRIPTION
With `parse.getAllNamedDefines` it is possible for me to filter the returned list of dependencies. 

Imagine a module bundle file A with 3 named defines A1, A2, and A3.

```
define('A3', function (a2) {
   ...
});

define('A2', ['A3', 'C'], function (a2) {
   ...
});

define('A1', ['A2', 'B'], function (a1) {
   ...
});

```

Since dependencies A2 and A3 are used internal, I don't really want to see them in the dependency list. With `parse.getAllNamedDefines` it is possible to filter the returned list. If needed, I could add this to the `findSimple` function (best via an option).

Also updated esprima.
